### PR TITLE
HH: add tree-level Higgs bosons to output

### DIFF
--- a/plugins/GenAnalyzer.cc
+++ b/plugins/GenAnalyzer.cc
@@ -410,7 +410,7 @@ std::vector<reco::GenParticle> GenAnalyzer::PartonsFromDecays(const std::vector<
 }
 
 // returns a vector with the gen particles from the decays of the particles in the list
-// saves decating particles in vector passed a reference
+// saves decaying particles in vector passed a reference
 std::vector<reco::GenParticle> GenAnalyzer::PartonsFromDecays(const std::vector<int> & pdgIds, std::vector<reco::GenParticle> & genDecay)  {
   
   // vector to save the partons
@@ -433,4 +433,23 @@ std::vector<reco::GenParticle> GenAnalyzer::PartonsFromDecays(const std::vector<
   }
 
   return partons;
+}
+
+// returns a vector with the first n particles which have pdgIDs
+std::vector<reco::GenParticle> GenAnalyzer::FirstNGenParticles(const std::vector<int> & pdgIds, std::size_t n)  {
+  
+  // vector to save the rtons
+  std::vector<reco::GenParticle> particles;
+
+  if(isRealData or PythiaLOSample) return particles;
+
+  for (auto & genParticle : *GenCollection ) {
+    // check if pdgid in vector
+    if (std::find(pdgIds.begin(), pdgIds.end(), genParticle.pdgId()) != pdgIds.end()) {
+          particles.emplace_back(genParticle);
+    }
+    if (particles.size() == n) return particles;
+  }
+
+  return particles;
 }

--- a/plugins/GenAnalyzer.h
+++ b/plugins/GenAnalyzer.h
@@ -44,6 +44,7 @@ class GenAnalyzer {
         virtual std::pair<float, float> GetQ2Weight(const edm::Event&);
         virtual std::vector<reco::GenParticle> PartonsFromDecays(const std::vector<int> & pdgIds);
         virtual std::vector<reco::GenParticle> PartonsFromDecays(const std::vector<int> & pdgIds, std::vector<reco::GenParticle> & genDecay );
+        virtual std::vector<reco::GenParticle> FirstNGenParticles(const std::vector<int> & pdgIds, std::size_t n); 
 
       
     private:

--- a/plugins/HHAnalyzer.cc
+++ b/plugins/HHAnalyzer.cc
@@ -202,6 +202,7 @@ void HHAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
 
     std::vector<reco::GenParticle> GenHsPart;
     std::vector<reco::GenParticle> GenBFromHsPart = theGenAnalyzer->PartonsFromDecays({25}, GenHsPart);
+    std::vector<reco::GenParticle> TL_GenHsPart = theGenAnalyzer->FirstNGenParticles({25}, 2);
 
 
     // --- Trigger selection ---
@@ -225,6 +226,7 @@ void HHAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     // gen level
     alp::convert(GenBFromHsPart, GenBFromHs);
     alp::convert(GenHsPart, GenHs);
+    alp::convert(TL_GenHsPart, TL_GenHs);
 
     // fill weights
     weightPairs.emplace_back("EventWeight", EventWeight);
@@ -291,6 +293,7 @@ void HHAnalyzer::beginJob() {
     tree->Branch("MET", &(alp_MET),64000,2);
     tree->Branch("GenBFromHs", &(GenBFromHs), 64000, 2);
     tree->Branch("GenHs", &(GenHs), 64000, 2);
+    tree->Branch("TL_GenHs", &(TL_GenHs), 64000, 2);
 
     tree->Branch("j_sort_pt", &(j_sort_pt), 64000, 2);
     tree->Branch("j_sort_csv", &(j_sort_csv), 64000, 2);

--- a/plugins/HHAnalyzer.h
+++ b/plugins/HHAnalyzer.h
@@ -164,6 +164,7 @@ class HHAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
         alp::Candidate alp_MET;
         std::vector<alp::Candidate> GenBFromHs;
         std::vector<alp::Candidate> GenHs;
+        std::vector<alp::Candidate> TL_GenHs;
 
         // for saving jet sortings
         std::vector<std::size_t> j_sort_pt;

--- a/python/HHAnalyzer.py
+++ b/python/HHAnalyzer.py
@@ -35,8 +35,8 @@ if len(options.inputFiles) == 0:
     process.source = cms.Source('PoolSource',
         fileNames = cms.untracked.vstring(
             # one single HH SM sample for test (events in DAS: 43877)
-            #'dcap://t2-srm-02.lnl.infn.it/pnfs/lnl.infn.it/data/cms//store/mc/RunIISpring16MiniAODv2/GluGluToHHTo4B_node_SM_13TeV-madgraph/MINIAODSIM/PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/70000/205E4ECB-FE3A-E611-9870-0CC47A1E046A.root'
-            'dcap://t2-srm-02.lnl.infn.it/pnfs/lnl.infn.it/data/cms//store/mc/RunIISpring16MiniAODv2/ST_t-channel_4f_leptonDecays_13TeV-amcatnlo-pythia8_TuneCUETP8M1/MINIAODSIM/premix_withHLT_80X_mcRun2_asymptotic_v14_ext1-v1/80000/02236588-E871-E611-BDA6-D8D385AE85C0.root'
+            'dcap://t2-srm-02.lnl.infn.it/pnfs/lnl.infn.it/data/cms//store/mc/RunIISpring16MiniAODv2/GluGluToHHTo4B_node_SM_13TeV-madgraph/MINIAODSIM/PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/70000/205E4ECB-FE3A-E611-9870-0CC47A1E046A.root'
+#            'dcap://t2-srm-02.lnl.infn.it/pnfs/lnl.infn.it/data/cms//store/mc/RunIISpring16MiniAODv2/ST_t-channel_4f_leptonDecays_13TeV-amcatnlo-pythia8_TuneCUETP8M1/MINIAODSIM/premix_withHLT_80X_mcRun2_asymptotic_v14_ext1-v1/80000/02236588-E871-E611-BDA6-D8D385AE85C0.root'
            # 'dcap://t2-srm-02.lnl.infn.it/pnfs/lnl.infn.it/data/cms//store/mc/RunIISpring16MiniAODv2/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext3-v1/20000/24658987-0032-E611-BC7A-0025905B85D6.root'
             #'root://xrootd-cms.infn.it///store/mc/RunIISpring16MiniAODv2/GluGluToHHTo4B_node_SM_13TeV-madgraph/MINIAODSIM/PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/70000/205E4ECB-FE3A-E611-9870-0CC47A1E046A.root'
             #'root://xrootd-cms.infn.it//store/mc/RunIISpring16MiniAODv2/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14_ext3-v1/80000/C014DCF9-AF3A-E611-A998-782BCB5094C5.root'
@@ -261,6 +261,7 @@ process.ntuple = cms.EDAnalyzer('HHAnalyzer',
         sample = cms.string( sample ),
         ewkFile = cms.string('%s/src/Analysis/ALPHA/data/scalefactors_v4.root' % os.environ['CMSSW_BASE']),
         applyEWK = cms.bool(True if sample.startswith('DYJets') or sample.startswith('WJets') else False),
+        applyTopPtReweigth = cms.bool(True if sample.startswith('TT_') else False),
         pythiaLOSample = cms.bool(False)
     ),
     pileupSet = cms.PSet(


### PR DESCRIPTION
Simple check performed, that both Higgs bosons are back to back in the transverse plane:
```
root [18] tree->Scan("abs(TL_GenHs[0].phi()-TL_GenHs[1].phi())")
************************
*    Row   * abs(TL_Ge *
************************
*        0 * 3.1415926 *
*        1 * 3.1415925 *
*        2 * 3.1415927 *
*        3 * 3.1415927 *
*        4 * 3.1415927 *
*        5 * 3.1415926 *
*        6 * 3.1415926 *
*        7 * 3.1415927 *
*        8 * 3.1415926 *
*        9 * 3.1415926 *
*       10 * 3.1415927 *
*       11 * 3.1415927 *
*       12 * 3.1415926 *
*       13 * 3.1415927 *
*       14 * 3.1415927 *
*       15 * 3.1415927 *
*       16 * 3.1415926 *
*       17 * 3.1415926 *
*       18 * 3.1415927 *
*       19 * 3.1415925 *
*       20 * 3.1415926 *
*       21 * 3.1415926 *
*       22 * 3.1415927 *
*       23 * 3.1415925 *
*       24 * 3.1415927 *
Type <CR> to continue or q to quit ==> q
************************
```